### PR TITLE
Use JSROOT FileProxy to access files from WebView

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,10 +111,12 @@
     "typescript": "^4.1.3",
     "vscode-test": "^1.5.0",
     "webpack": "^5.73.0",
-    "webpack-cli": "^4.10.0"
+    "webpack-cli": "^4.10.0",
+    "atob": "^2.1.2",
+    "btoa": "^1.2.1"
   },
   "dependencies": {
-    "jsroot": "^7.1.0"
+    "jsroot": "file:../jsroot"
   },
   "bugs": {
     "url": "https://github.com/albertopdrf/root-file-viewer/issues"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "jsroot": "file:../jsroot"
+    "jsroot": "root-project/jsroot#master"
   },
   "bugs": {
     "url": "https://github.com/albertopdrf/root-file-viewer/issues"

--- a/package.json
+++ b/package.json
@@ -111,9 +111,7 @@
     "typescript": "^4.1.3",
     "vscode-test": "^1.5.0",
     "webpack": "^5.73.0",
-    "webpack-cli": "^4.10.0",
-    "atob": "^2.1.2",
-    "btoa": "^1.2.1"
+    "webpack-cli": "^4.10.0"
   },
   "dependencies": {
     "jsroot": "file:../jsroot"

--- a/src/rootFileEditor.ts
+++ b/src/rootFileEditor.ts
@@ -2,6 +2,9 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { Disposable } from "./dispose";
 
+// import * as fs from "fs";
+
+
 class RootFileDocument extends Disposable implements vscode.CustomDocument {
   static async create(
     uri: vscode.Uri
@@ -82,6 +85,14 @@ export class RootFileEditorProvider
       webviewPanel.webview,
       document.uri
     );
+
+    // let fd = fs.openSync(document.uri, 'r'), size = -1;
+    // if (fd) {
+    //   let stats = fs.statSync(document.uri);
+    //   size = stats.size;
+    // }
+
+    webviewPanel.webview.postMessage({ info: "Say hello size = " + size });
   }
 
   private getHtmlForWebview(webview: vscode.Webview, file: vscode.Uri): string {
@@ -141,6 +152,12 @@ export class RootFileEditorProvider
             }
 
             h.openRootFile("${fileUri}");
+          });
+
+          // Handle the message inside the webview
+          window.addEventListener('message', event => {
+            const message = event.data; // The JSON data our extension sent
+            console.log('got message', message?.info);
           });
         </script>
       </body>

--- a/src/rootFileEditor.ts
+++ b/src/rootFileEditor.ts
@@ -108,6 +108,12 @@ export class RootFileEditorProvider
             case 'alert':
                vscode.window.showErrorMessage(message.text);
                return;
+            case 'save':
+               // let fs = require('fs');       // this is native "fs" module
+               // let atob = require('atob');   // this should be "atob" module
+               // fs.writeFileSync(message.filename, atob(message.content)); // save binary file
+               vscode.window.showInformationMessage(`Want to save file ${message.filename} base64 content ${message.content.length}`);
+               return;
             case 'read': {
                let buffer = new ArrayBuffer(message.sz);
                let view = new DataView(buffer, 0, message.sz);
@@ -238,6 +244,14 @@ export class RootFileEditorProvider
              text: 'test message for alert command'
           });
 
+          JSROOT.setSaveFile((filename, content) => {
+             // here binary content
+             vscode.postMessage({
+                command: 'save',
+                filename,
+                content: window.btoa(content)
+             });
+          });
 
         </script>
       </body>

--- a/src/rootFileEditor.ts
+++ b/src/rootFileEditor.ts
@@ -146,8 +146,8 @@ export class RootFileEditorProvider
     const fileUri = webview.asWebviewUri(file);
 
     const configuration = vscode.workspace.getConfiguration("rootFileViewer");
-    const darkMode = configuration.get("darkMode");
-    const layout = configuration.get("layout");
+    const darkMode = true; // configuration.get("darkMode");
+    const layout = "tabs"; // configuration.get("layout");
     const palette = configuration.get("palette");
 
 
@@ -189,7 +189,6 @@ export class RootFileEditorProvider
 
             readBuffer(pos, sz)
             {
-               console.log('readByffer', pos, sz);
                return new Promise(resolve => {
                   requests[++id] = resolve;
                   vscode.postMessage({

--- a/src/rootFileEditor.ts
+++ b/src/rootFileEditor.ts
@@ -84,8 +84,6 @@ export class RootFileEditorProvider
 
     const fileUri = webviewPanel.webview.asWebviewUri(document.uri);
 
-    let btoa = require('btoa');   // this is "btoa" module
-    let atob = require('atob');   // this is "atob" module
     let fs = require('fs');       // this is native "fs" module
 
     let filename = fileUri?.path;
@@ -109,19 +107,19 @@ export class RootFileEditorProvider
                vscode.window.showErrorMessage(message.text);
                return;
             case 'save':
-               fs.writeFileSync(message.filename, atob(message.content)); // save binary file
-               vscode.window.showInformationMessage(`Want to save file ${message.filename} base64 content ${message.content.length}`);
+               fs.writeFileSync(message.filename, Buffer.from(message.content, 'base64')); // save binary file
+               vscode.window.showInformationMessage(`Saving file ${message.filename} base64 len ${message.content.length}`);
                return;
             case 'read': {
                let buffer = new ArrayBuffer(message.sz);
                let view = new DataView(buffer, 0, message.sz);
-               let bytesRead = fs.readSync(fd, view, 0, message.sz, message.pos);
-               let binStr = "";
-               for (let i = 0; i < message.sz; ++i)
-                  binStr += String.fromCharCode(view.getUint8(i));
+               /* let bytesRead = */ fs.readSync(fd, view, 0, message.sz, message.pos);
+               //let binStr = "";
+               //for (let i = 0; i < message.sz; ++i)
+               //   binStr += String.fromCharCode(view.getUint8(i));
                webviewPanel.webview.postMessage({
                    id: message.id,
-                   read: btoa(binStr)
+                   read: Buffer.from(buffer).toString('base64')
                 });
                return;
             }

--- a/src/rootFileEditor.ts
+++ b/src/rootFileEditor.ts
@@ -86,13 +86,26 @@ export class RootFileEditorProvider
       document.uri
     );
 
-    // let fd = fs.openSync(document.uri, 'r'), size = -1;
+    let size = 0;
+
+    // let fs = require('fs');
+    // let fd = fs.openSync(document.uri, 'r');
     // if (fd) {
-    //   let stats = fs.statSync(document.uri);
-    //   size = stats.size;
+    // let stats = fs.statSync(document.uri);
+    //  size = stats.size;
     // }
 
     webviewPanel.webview.postMessage({ info: "Say hello size = " + size });
+
+    webviewPanel.webview.onDidReceiveMessage(
+        message => {
+          switch (message.command) {
+            case 'alert':
+              vscode.window.showErrorMessage(message.text);
+              return;
+          }
+        }
+    );
   }
 
   private getHtmlForWebview(webview: vscode.Webview, file: vscode.Uri): string {
@@ -158,6 +171,12 @@ export class RootFileEditorProvider
           window.addEventListener('message', event => {
             const message = event.data; // The JSON data our extension sent
             console.log('got message', message?.info);
+          });
+
+          const vscode = acquireVsCodeApi();
+          vscode.postMessage({
+             command: 'alert',
+             text: 'test message for alert command'
           });
         </script>
       </body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,6 @@ const config = {
     devtool: 'source-map',
     externals: {
       vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
-      atob: 'atob',
-      btoa: 'btoa',
       fs: 'fs'
     },
     resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ const CopyPlugin = require("copy-webpack-plugin");
 /**@type {import('webpack').Configuration}*/
 const config = {
     target: 'webworker', // vscode extensions run in webworker context for VS Code web 📖 -> https://webpack.js.org/configuration/target/#target
-  
+
     entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
     output: {
       // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
@@ -21,7 +21,10 @@ const config = {
     },
     devtool: 'source-map',
     externals: {
-      vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+      vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+      atob: 'atob',
+      btoa: 'btoa',
+      fs: 'fs'
     },
     resolve: {
       // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader


### PR DESCRIPTION
I introduce `FileProxy` class in JSROOT and will try to use it here.
Idea that binary data from the file can be read though such proxy.

That I am missing - how node modules can be used on `Code` side?
You see commented lines:

```javascript
    // let btoa = require('btoa');   // this should be "btoa" module
    // let fs = require('fs');       // this is native "fs" module
    // let fd = fs.openSync(filename, 'r');
    // if (fd) {
    // let stats = fs.statSync(filename.uri);
    //  filesize = stats.size;
    // }
```

I need standard "fs" module and "btoa" module from node.
Also would be nice if you could help to produce filename which can be used to read file content.
